### PR TITLE
Mac uuencode does not support the --base64 option

### DIFF
--- a/bin/Makefile
+++ b/bin/Makefile
@@ -11,7 +11,7 @@ Classes.txt: com/github/phf/jb/*.class
 
 jaybee: jaybee.jar
 	cat Executable.txt >$@
-	uuencode --base64 $^ <$^ >>$@
+	uuencode $^ <$^ >>$@
 	chmod +x $@
 
 clean:


### PR DESCRIPTION
Remove the --base64 option since it is not supported on mac